### PR TITLE
Ajout de Jest et tests pour genCodeIntervention

### DIFF
--- a/genCodeIntervention.js
+++ b/genCodeIntervention.js
@@ -1,0 +1,13 @@
+function genCodeIntervention() {
+  const now = new Date();
+  const pad = n => n.toString().padStart(2, "0");
+  const yyyy = now.getFullYear();
+  const mm = pad(now.getMonth() + 1);
+  const dd = pad(now.getDate());
+  const h = pad(now.getHours());
+  const m = pad(now.getMinutes());
+  const rnd = () => Math.random().toString(36).substring(2, 6).toUpperCase();
+  return `GRILL-${yyyy}${mm}${dd}-${h}${m}-${rnd()}`;
+}
+
+module.exports = genCodeIntervention;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Ce petit projet propose un formulaire permettant aux clients de signaler un problème technique ou de laisser un avis concernant leur séjour à l'hôtel. Lors de la soumission, un PDF récapitulatif est généré grâce à la librairie **jsPDF** puis le contenu du formulaire est envoyé via **Formspree**.",
   "main": "script.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "lint": "eslint ."
   },
   "keywords": [],
@@ -12,6 +12,7 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "eslint": "^9.29.0"
+    "eslint": "^9.29.0",
+    "jest": "^30.0.0"
   }
 }

--- a/tests/genCodeIntervention.test.js
+++ b/tests/genCodeIntervention.test.js
@@ -1,0 +1,6 @@
+const genCodeIntervention = require('../genCodeIntervention');
+
+test('le code généré a le bon format', () => {
+  const code = genCodeIntervention();
+  expect(code).toMatch(/^GRILL-\d{8}-\d{4}-[A-Z0-9]{4}$/);
+});


### PR DESCRIPTION
## Notes
- Installation de Jest comme dépendance de développement
- Ajout d'un fichier `genCodeIntervention.js` exportant la fonction
- Création du dossier `tests/` avec un test Jest
- Mise à jour du script `test` dans `package.json`

## Résultats des tests
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684f34c277bc8324b8a7488ce8c007b0