### PR TITLE
Corrige réinitialisation du formulaire

### DIFF
--- a/script.js
+++ b/script.js
@@ -460,20 +460,20 @@ document.getElementById('mainForm').onsubmit = function(e){
   });
   document.getElementById('hiddenMessage').value = hiddenMsg;
 
-  // Reset wizard & UI avant envoi
-  document.getElementById('mainForm').reset();
-  chemin = [];
-  autreSaisie = "";
-  avisSaisie = "";
-  conflitChambres = [];
-  conflitComment = "";
-  multi = [];
-  renderWizard();
-  renderMultiList();
-
   // Envoie du formulaire après génération PDF (laisse 400ms pour download propre)
   setTimeout(function() {
     document.getElementById('mainForm').submit();
+
+    // Reset wizard & UI après envoi
+    document.getElementById('mainForm').reset();
+    chemin = [];
+    autreSaisie = "";
+    avisSaisie = "";
+    conflitChambres = [];
+    conflitComment = "";
+    multi = [];
+    renderWizard();
+    renderMultiList();
   }, 400);
 
   return false;


### PR DESCRIPTION
## Notes
- Déplacement du `reset()` après la soumission pour ne plus effacer `hiddenMessage` avant l'envoi.
- `hiddenMessage` est maintenant conservé jusqu'à l'appel de `submit()`.

## Résultats des tests
- `npm test` : tous les tests passent.
- `npm run lint` : pas d'erreurs.


------
https://chatgpt.com/codex/tasks/task_e_684f400c107c8324b417a0955c52700c