### PR TITLE
Mettre à jour README pour NPM install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ cd hotel_avis
 npm install
 ```
 
+Cette commande télécharge notamment `jest` et `eslint`, indispensables pour exécuter `npm test` et `npm run lint`. Veillez à disposer d'un accès réseau lors de cette étape.
 Vous pouvez ensuite lancer les tests et le linter :
 
 ```bash


### PR DESCRIPTION
## Summary
- expliquer qu'un accès réseau est nécessaire pour `npm install` qui installe `jest` et `eslint`

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f420eb5608324bfd84bf3b8d50713