### PR TITLE
Ajout tutoriel Formspree et explications

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Ce petit projet propose un formulaire permettant aux clients de signaler un prob
 
 Après un envoi réussi, le bouton **Télécharger la fiche** apparaît pour générer ce PDF à la demande.
 
+## Présentation complète
+
+Cet outil a été pensé pour simplifier la collecte de retours au sein de l'hôtel :
+
+- **HTML/CSS/JavaScript** assurent l'interface et la logique du formulaire ;
+- **Formspree** réceptionne les données et les transmet par courriel ;
+- **jsPDF** génère localement une fiche au format PDF, téléchargeable après validation.
+
+L'application fonctionne sans dépendance serveur : toute la logique est côté client et le stockage temporaire des préférences (thème) se fait dans `localStorage`.
+
 ## Cloner le dépôt
 
 ```bash
@@ -38,16 +48,56 @@ La page charge **jsPDF** en version **2.5.1** :
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 ```
 
-## Modifier l'adresse Formspree
+## Tutoriel : configurer Formspree
 
-1. Créez votre propre formulaire sur [Formspree](https://formspree.io/).
-2. Copiez l'URL fournie par Formspree.
-3. Dans `index.html`, remplacez l'attribut `action` du formulaire par cette nouvelle URL :
+Suivez ces étapes pour que le formulaire arrive sur votre propre adresse e‑mail :
+
+1. Rendez‑vous sur [Formspree](https://formspree.io/) et créez un compte.
+2. Validez l'adresse e‑mail utilisée lors de l'inscription (un lien de confirmation est envoyé par Formspree).
+3. Dans votre tableau de bord, créez un nouveau formulaire. Formspree fournit une URL de type `https://formspree.io/f/abcde123`.
+4. Ouvrez `index.html` et modifiez l'attribut `action` du formulaire avec cette URL :
    ```html
-   <form id="mainForm" action="https://formspree.io/f/monidentifiant" method="POST">
+   <form id="mainForm" action="https://formspree.io/f/abcde123" method="POST">
    ```
-4. Facultatif : décommentez la ligne contenant le champ `_next` pour rediriger l'utilisateur vers votre page de remerciement personnalisée :
+5. Pour afficher une page personnalisée après l'envoi, décommentez ou ajoutez le champ `_next` :
    ```html
    <input type="hidden" name="_next" value="https://votresite.exemple/merci.html">
    ```
+
+## Fonctionnement de l'envoi vers Formspree
+
+Le fichier `script.js` gère l'appel réseau lors de la soumission du formulaire.
+Les lignes 491&nbsp;à&nbsp;504 réalisent notamment :
+
+1. **Récupération du formulaire et de ses données**
+   ```javascript
+   const form = document.getElementById('mainForm');
+   const formData = new FormData(form);
+   const formAction = form.getAttribute('action');
+   ```
+2. **Envoi en AJAX** via `fetch` sur l'URL Formspree :
+   ```javascript
+   fetch(formAction, {
+     method: 'POST',
+     body: formData,
+     headers: { 'Accept': 'application/json' }
+   }).then(response => {
+   ```
+3. **Traitement de la réponse** : si tout se passe bien (`response.ok`),
+   l'application affiche le bouton de téléchargement et réinitialise le
+   formulaire :
+   ```javascript
+   if (response.ok) {
+     lastSubmissionData = { nom, chambre, multi: JSON.parse(JSON.stringify(multi)), codeInter };
+     document.getElementById('download-btn').classList.remove('hidden');
+     document.getElementById('mainForm').reset();
+     // ... remise à zéro des variables internes ...
+   }
+   ```
+   En cas d'erreur ou de problème réseau, un message d'alerte s'affiche afin de
+   prévenir l'utilisateur.
+
+## Licence
+
+Ce projet est distribué sous licence [MIT](LICENSE). Des versions du présent fichier existent en anglais et en arabe dans `README.en.md` et `README.ar.md`.
 

--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
   <div class="main-containers">
     <div class="container container-buanderie">
       <h2>🛎️ Hôtel Grill</h2>
-      <!-- FORMULAIRE PATCHÉ POUR FORMSPREE -->
-      <form id="mainForm" autocomplete="off" action="https://formspree.io/f/mqabbdyg" method="POST">
+      <!-- FORMULAIRE PATCHÉ POUR FORMSPREE: remplacez l'URL par celle de votre formulaire -->
+      <form id="mainForm" autocomplete="off" action="https://formspree.io/f/monFormulaire" method="POST">
         <label>Nom :</label>
         <input type="text" id="nom" name="nom" required autocomplete="off"
                placeholder="Saisissez votre nom">
@@ -49,7 +49,7 @@
         <!-- CHAMP CACHÉ POUR LES DÉTAILS (wizard/message) -->
         <input type="hidden" id="hiddenMessage" name="message">
 
-        <!-- Pour page de remerciement custom, décommente ci-dessous -->
+        <!-- Pour page de remerciement custom, décommentez et remplacez l'URL ci-dessous -->
         <!--
         <input type="hidden" name="_next" value="https://tonsite.github.io/merci.html">
         -->


### PR DESCRIPTION
## Summary
- enrichir `README.md` avec une section de présentation
- ajouter un tutoriel détaillé pour configurer Formspree
- expliquer le code d'envoi (lignes 491‑504 de `script.js`)
- référencer la licence MIT et les autres README
- mettre un placeholder et des commentaires dans `index.html`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850694cf6dc83248d0a6a1223a9670b