### PR TITLE
Update license to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "type": "commonjs",
   "devDependencies": {
     "eslint": "^9.29.0",


### PR DESCRIPTION
## Summary
- change `package.json` license field to MIT
- verified that all READMEs mention the MIT license

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68506b8da7d48324975b92e5b7237bbb